### PR TITLE
Mounting reset

### DIFF
--- a/bindings/actions.json
+++ b/bindings/actions.json
@@ -146,6 +146,11 @@
       "requirement": "optional"
     },
     {
+      "name": "/actions/main/in/mounting_reset",
+      "type": "boolean",
+      "requirement": "optional"
+    },
+    {
       "name": "/actions/main/in/pause_tracking",
       "type": "boolean",
       "requirement": "optional"

--- a/bindings/actions.json
+++ b/bindings/actions.json
@@ -173,8 +173,8 @@
       "/actions/main/in/waist": "Waist",
       "/actions/main/in/foot_left": "Left Foot",
       "/actions/main/in/foot_right": "Right Foot",
-      "/actions/main/in/request_calibration": "Reset",
-      "/actions/main/in/fast_reset": "Fast Reset",
+      "/actions/main/in/request_calibration": "Full Reset",
+      "/actions/main/in/fast_reset": "Yaw Reset",
       "/actions/main/in/mounting_reset": "Mounting Reset",
       "/actions/main/in/pause_tracking": "Pause Tracking"
     }

--- a/bindings/actions.json
+++ b/bindings/actions.json
@@ -175,6 +175,7 @@
       "/actions/main/in/foot_right": "Right Foot",
       "/actions/main/in/request_calibration": "Reset",
       "/actions/main/in/fast_reset": "Fast Reset",
+      "/actions/main/in/mounting_reset": "Mounting Reset",
       "/actions/main/in/pause_tracking": "Pause Tracking"
     }
   ]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -859,6 +859,7 @@ int main(int argc, char* argv[]) {
 
 	VRActionHandle_t calibration_action = GetAction("/actions/main/in/request_calibration");
 	VRActionHandle_t fast_reset_action = GetAction("/actions/main/in/fast_reset");
+	VRActionHandle_t mounting_reset_action = GetAction("/actions/main/in/mounting_reset");
 	VRActionHandle_t pause_tracking_action = GetAction("/actions/main/in/pause_tracking");
 
 	//trackers.Detect(false);
@@ -932,6 +933,7 @@ int main(int argc, char* argv[]) {
 		// TODO: rename these actions as appropriate, perhaps log them?
 		trackers.HandleDigitalActionBool(calibration_action, { "reset" });
 		trackers.HandleDigitalActionBool(fast_reset_action, { "fast_reset" });
+		trackers.HandleDigitalActionBool(mounting_reset_action, { "mounting_reset" });
 		trackers.HandleDigitalActionBool(pause_tracking_action, { "pause_tracking" });
 
 		trackers.Tick(just_connected);


### PR DESCRIPTION
Closes #29 and requires https://github.com/SlimeVR/SlimeVR-Server/pull/1473

Placed mounting before pause to keep resets grouped together, also renamed "Reset" to "Full Reset" and "Fast Reset" to "Yaw Reset" so they match the modern terminology.